### PR TITLE
Fix thcrap_loader hanging after quitting game

### DIFF
--- a/thcrap_proton
+++ b/thcrap_proton
@@ -86,5 +86,23 @@ echo "--------------------GENERATED COMMAND--------------------"
 echo "$COMMAND"
 echo "---------------------------------------------------------"
 
-sh -c "$COMMAND"
+sh -c "$COMMAND" &
 
+# Give the main executable time to launch
+sleep 10
+
+# Get PID while ensuring only the actual Touhou executable is chosen
+TH_PID=$(pgrep -fn "$th[0-19].exe")
+
+cleanup() {
+    # Find and kill the thcrap_loader process
+    pkill -f "thcrap_loader.exe"
+}
+
+# Set up the trap to call the cleanup function when the script exits
+trap cleanup EXIT
+
+# Check if Touhou is still running
+while kill -0 $TH_PID 2>/dev/null; do
+    sleep 5
+done

--- a/thcrap_proton
+++ b/thcrap_proton
@@ -92,7 +92,7 @@ sh -c "$COMMAND" &
 
 # Get PID while ensuring only the actual Touhou executable is chosen
 while [ -z "$TH_PID" ]; do # Loop until a matching process is found
-    TH_PID=$(pgrep -a "$TH_REGEX" | grep -iE "$TH_REGEX" | awk '{print $1}')
+    TH_PID=$(pgrep "$TH_REGEX")
     sleep 5
 done
 

--- a/thcrap_proton
+++ b/thcrap_proton
@@ -93,7 +93,7 @@ sh -c "$COMMAND" &
 sleep $WAIT_TIME
 
 # Get PID while ensuring only the actual Touhou executable is chosen
-TH_PID=$(pgrep -fn "$th[0-19].exe")
+TH_PID=$(pgrep -fn "$th[0-9]+\.exe")
 
 cleanup() {
     # Find and kill the thcrap_loader process

--- a/thcrap_proton
+++ b/thcrap_proton
@@ -2,7 +2,6 @@
 
 THCRAP_FOLDER="/home/$USER/.local/share/thcrap"
 THCRAP_CONFIG=en.js
-WAIT_TIME=10 # Increase this if the game takes a while to load and thcrap_loader still hangs
 
 ZENITY=${STEAM_ZENITY:-$(which zenity)}
 
@@ -92,18 +91,13 @@ sh -c "$COMMAND" &
 # Get PID while ensuring only the actual Touhou executable is chosen
 while [ -z "$TH_PID" ]; do # Loop until a matching process is found
     TH_PID=$(pgrep -a "$th[0-9]+\.exe" | \grep -i "$th[0-9].exe" | awk '{print $1}')
-    sleep $WAIT_TIME
+    sleep 5
 done
-
-cleanup() {
-    # Find and kill the thcrap_loader process
-    pkill -f "thcrap_loader.exe"
-}
-
-# Set up the trap to call the cleanup function when the script exits
-trap cleanup EXIT
 
 # Check if Touhou is still running
 while kill -0 $TH_PID 2>/dev/null; do
     sleep 5
 done
+
+# Find and kill the thcrap_loader process
+pkill -f "thcrap_loader.exe"

--- a/thcrap_proton
+++ b/thcrap_proton
@@ -2,6 +2,7 @@
 
 THCRAP_FOLDER="/home/$USER/.local/share/thcrap"
 THCRAP_CONFIG=en.js
+WAIT_TIME=10 # Increase this if the game takes a while to load and thcrap_loader still hangs
 
 ZENITY=${STEAM_ZENITY:-$(which zenity)}
 
@@ -89,7 +90,7 @@ echo "---------------------------------------------------------"
 sh -c "$COMMAND" &
 
 # Give the main executable time to launch
-sleep 10
+sleep $WAIT_TIME
 
 # Get PID while ensuring only the actual Touhou executable is chosen
 TH_PID=$(pgrep -fn "$th[0-19].exe")

--- a/thcrap_proton
+++ b/thcrap_proton
@@ -70,10 +70,12 @@ if [ ! -f "$THCRAP_FOLDER/config/$THCRAP_CONFIG" ]; then
     fi
 fi
 
+TH_REGEX="th[0-9]+\.exe"
+
 if [ "$USE_VPATCH" == 1 ]; then
     COMMAND=$(
         echo "$COMMAND" |
-        sed -r 's/th[0-9]*.exe/vpatch.exe/'
+        sed -r "s/$TH_REGEX/vpatch.exe/"
     )
 fi
 
@@ -90,7 +92,7 @@ sh -c "$COMMAND" &
 
 # Get PID while ensuring only the actual Touhou executable is chosen
 while [ -z "$TH_PID" ]; do # Loop until a matching process is found
-    TH_PID=$(pgrep -a "th[0-9]+\.exe" | grep -iE "th[0-9]+\.exe" | awk '{print $1}')
+    TH_PID=$(pgrep -a "$TH_REGEX" | grep -iE "$TH_REGEX" | awk '{print $1}')
     sleep 5
 done
 

--- a/thcrap_proton
+++ b/thcrap_proton
@@ -90,12 +90,12 @@ sh -c "$COMMAND" &
 
 # Get PID while ensuring only the actual Touhou executable is chosen
 while [ -z "$TH_PID" ]; do # Loop until a matching process is found
-    TH_PID=$(pgrep -a "$th[0-9]+\.exe" | \grep -i "$th[0-9].exe" | awk '{print $1}')
+    TH_PID=$(pgrep -a "th[0-9]+\.exe" | grep -iE "th[0-9]+\.exe" | awk '{print $1}')
     sleep 5
 done
 
 # Check if Touhou is still running
-while kill -0 $TH_PID 2>/dev/null; do
+while ps -p $TH_PID > /dev/null; do
     sleep 5
 done
 

--- a/thcrap_proton
+++ b/thcrap_proton
@@ -89,11 +89,11 @@ echo "---------------------------------------------------------"
 
 sh -c "$COMMAND" &
 
-# Give the main executable time to launch
-sleep $WAIT_TIME
-
 # Get PID while ensuring only the actual Touhou executable is chosen
-TH_PID=$(pgrep -fn "$th[0-9]+\.exe")
+while [ -z "$TH_PID" ]; do # Loop until a matching process is found
+    TH_PID=$(pgrep -a "$th[0-9]+\.exe" | \grep -i "$th[0-9].exe" | awk '{print $1}')
+    sleep $WAIT_TIME
+done
 
 cleanup() {
     # Find and kill the thcrap_loader process


### PR DESCRIPTION
I noticed that for me and some others that `thcrap_loader.exe` hangs after the game is quit, preventing Steam from detecting that the game is closed. So, I updated the script to detect when the actual Touhou executable closes and run a command to kill the remaining thcrap process.

This is actually my first time writing (let alone modifying to this extend) a bash script, so it might be a little rough, not sure. I've tested it and it seems to run just fine.

I'll leave this PR as a draft for now as I test it some more.