### PR TITLE
Add thprac support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # thcrap-steam-proton-wrapper
 ## Introduction
-A wrapper script for launching the official Touhou games on Steam with the [Touhou Community Reliant Automatic Patcher](https://www.thpatch.net/) (thcrap), and optionally the [Vsync patch](https://en.touhouwiki.net/wiki/Game_Tools_and_Modifications#Vsync_Patches) (vpatch), from the Steam client using [Proton](<https://en.wikipedia.org/wiki/Proton_(software)>) on GNU/Linux.
+A wrapper script for launching the official Touhou games on Steam with the [Touhou Community Reliant Automatic Patcher](https://www.thpatch.net/) (thcrap), and optionally the [Vsync patch](https://en.touhouwiki.net/wiki/Game_Tools_and_Modifications#Vsync_Patches) (vpatch) and [thprac](https://github.com/touhouworldcup/thprac), from the Steam client using [Proton](<https://en.wikipedia.org/wiki/Proton_(software)>) on GNU/Linux.
 
 This script works by setting up and managing a global thcrap instance, launching the configuration tool when needed, all without user intervention.
 
@@ -43,27 +43,49 @@ If you have gone through the manual installation, you have the opportunity to ch
 Go to your Steam library -> right click the game -> Properties -> and edit the launch options to:
 
     thcrap_proton -- %command%
-   
+
 In case you have put your script outside `/usr/local/bin/`, you'll have to provide the full path:
-   
+
     /path/to/thcrap_proton -- %command%
 
 This is the base command, which will run the game with the default config.
 
-To change the config file loaded by thcrap, use the `-c` flag.
+#### thcrap config file
+The default config is `THCRAP_CONFIG`, set to `en.js` if unmodified in the script.
+To change the config file loaded by thcrap, use the `-c` flag, like this:
 
-To enable vpatch for that game, include the `-v` flag.
-   
-**Note that this script does not install vpatch on it's own.**
+    thcrap_proton -c pt-br.js -- %command%
 
-So, if I wanted to run the game with vpatch and Brazilian Portuguese translations, the command would look like this:
-       
-    thcrap_proton -v -c pt-br.js -- %command%
+would run the game with Brazilian Portuguese translations.
+
+After installation, you can find all installed configs at `$THCRAP_FOLDER/config`.
 
 **Note: the `%command%` always comes at the end**
 
+#### vpatch (optional)
+To enable vpatch for that game, include the `-v` flag, like this:
+
+    thcrap_proton -v -- %command%
+
+**Note that this script does not install vpatch on it's own.**
+
+#### thprac (optional)
+To enable thprac for that game, use the `-p` flag, like this:
+
+    thcrap_proton -p -- %command%
+
+The script will download and install thprac to `THPRAC_FOLDER`.
+Default location is `/home/$USER/.local/share/thprac`.
+
+Upon launching thprac will ask whether to apply to the ongoing game, if running game
+in full screen mode you may need to minimize the game to see the dialog box.
+To [change thprac language](https://github.com/touhouworldcup/thprac?tab=readme-ov-file#how-do-i-switch-language),
+don't attach thprac to ongoing game when prompted and it will start a launcher.
+Then change language in thprac setting.
+
+#### Extra environment variables (optional)
 If you want to use any environment variables in your launch options, you can put them before the `%command%`, like this:
-   
+
     thcrap_proton -- PROTON_USE_WINED3D=1 %command%
 
 ### 4. Running the game

--- a/thcrap_proton
+++ b/thcrap_proton
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-THCRAP_FOLDER="/home/$USER/.local/share/thcrap"
+[ -z "$XDG_DATA_HOME" ] && XDG_DATA_HOME="$HOME/.local/share"
+THCRAP_FOLDER="$XDG_DATA_HOME/thcrap"
 THCRAP_CONFIG=en.js
 
 ZENITY=$(which zenity)

--- a/thcrap_proton
+++ b/thcrap_proton
@@ -17,9 +17,10 @@ launch_config() {
     sh -c "$RUN"
 }
 
-while getopts "v c:e:" flag; do
+while getopts "v c:p:e:" flag; do
     case "${flag}" in
         v) USE_VPATCH=1;;
+        p) THPRAC_EXE=${OPTARG};;
         c) THCRAP_CONFIG=${OPTARG};;
         e) COMMAND=${OPTARG};; # Deprecated
     esac
@@ -90,6 +91,17 @@ echo "$COMMAND"
 echo "---------------------------------------------------------"
 
 sh -c "$COMMAND" &
+
+if [ -n "$THPRAC_EXE" ]; then
+    # wait 5s and launch thprac so it could auto attach to the game
+    sleep 5
+    PROTON_CMD=$( echo "$COMMAND" | sed -n "s/^.*-- \(.*\) waitforexitandrun.*$/\\1/p" )
+    RUN_THPRAC="$PROTON_CMD run '$THPRAC_EXE'"
+    echo "-----------------------THPRAC COMMAND--------------------"
+    echo "$RUN_THPRAC"
+    echo "---------------------------------------------------------"
+    sh -c "$RUN_THPRAC" &
+fi
 
 # Get PID while ensuring only the actual Touhou executable is chosen
 while [ -z "$TH_PID" ]; do # Loop until a matching process is found

--- a/thcrap_proton
+++ b/thcrap_proton
@@ -4,6 +4,9 @@
 THCRAP_FOLDER="$XDG_DATA_HOME/thcrap"
 THCRAP_CONFIG=en.js
 
+# This is `thprac` not `thcrap`
+THPRAC_FOLDER="$XDG_DATA_HOME/thprac"
+
 ZENITY=$(which zenity)
 
 echo "" > '/tmp/thcrap_proton.log'
@@ -18,10 +21,10 @@ launch_config() {
     sh -c "$RUN"
 }
 
-while getopts "v c:p:e:" flag; do
+while getopts "vp c:e:" flag; do
     case "${flag}" in
         v) USE_VPATCH=1;;
-        p) THPRAC_EXE=${OPTARG};;
+        p) USE_THPRAC=1;;
         c) THCRAP_CONFIG=${OPTARG};;
         e) COMMAND=${OPTARG};; # Deprecated
     esac
@@ -73,6 +76,32 @@ if [ ! -f "$THCRAP_FOLDER/config/$THCRAP_CONFIG" ]; then
     fi
 fi
 
+if [ "$USE_THPRAC" == 1 ]; then
+    THPRAC_VERSION=$(LD_LIBRARY_PATH=/usr/lib64:/usr/lib curl --connect-timeout 5 -si https://github.com/touhouworldcup/thprac/releases/latest | grep location: | sed 's@.*/@@' | tr -d '[:space:]')
+    if [[ -n "$THPRAC_VERSION" && ! -f "$THPRAC_FOLDER/thprac.$THPRAC_VERSION.exe" ]]; then
+        # Install latest version
+        mkdir -p "$THPRAC_FOLDER"
+        if [ ! -w "$THPRAC_FOLDER" ]; then
+            ${ZENITY} --error --text="The directory \"$THPRAC_FOLDER\" could not be created or is not writable. Check your permissions and try again."
+            exit
+        fi
+        LD_LIBRARY_PATH=/usr/lib64:/usr/lib curl -L -f "https://github.com/touhouworldcup/thprac/releases/download/$THPRAC_VERSION/thprac.$THPRAC_VERSION.exe" -o "$THPRAC_FOLDER/thprac.$THPRAC_VERSION.exe" | ${ZENITY} --progress --pulsate --auto-close --text="Downloading \"thprac.$THPRAC_VERSION.exe\""
+        if [ $? = 0 ]; then
+            # Create a symlink to latest version
+            ln -srf "$THPRAC_FOLDER/thprac.$THPRAC_VERSION.exe" "$THPRAC_FOLDER/thprac.exe"
+            # Remove old versions, only keep the latest version
+            find "$THPRAC_FOLDER" -maxdepth 1 -name "thprac.*.exe" \! -name "thprac.$THPRAC_VERSION.exe" -exec rm {} \;
+        fi
+    fi
+
+    # Make sure thprac is installed
+    if [ ! -f "$THPRAC_FOLDER/thprac.exe" ]; then
+        # no installed version
+        ${ZENITY} --error --text="thprac installation failed. Aborting"
+        exit
+    fi
+fi
+
 TH_REGEX="(th[0-9]+|東方紅魔郷)"
 
 if [ "$USE_VPATCH" == 1 ]; then
@@ -93,11 +122,11 @@ echo "---------------------------------------------------------"
 
 sh -c "$COMMAND" &
 
-if [ -n "$THPRAC_EXE" ]; then
+if [ "$USE_THPRAC" == 1 ]; then
     # wait 5s and launch thprac so it could auto attach to the game
     sleep 5
     PROTON_CMD=$( echo "$COMMAND" | sed -n "s/^.*-- \(.*\) waitforexitandrun.*$/\\1/p" )
-    RUN_THPRAC="$PROTON_CMD run '$THPRAC_EXE'"
+    RUN_THPRAC="$PROTON_CMD run '$THPRAC_FOLDER/thprac.exe'"
     echo "-----------------------THPRAC COMMAND--------------------"
     echo "$RUN_THPRAC"
     echo "---------------------------------------------------------"

--- a/thcrap_proton
+++ b/thcrap_proton
@@ -134,7 +134,7 @@ fi
 
 # Get PID while ensuring only the actual Touhou executable is chosen
 while [ -z "$TH_PID" ]; do # Loop until a matching process is found
-    TH_PID=$(grep -Er "$TH_REGEX" /proc/*/stat | sed "s/.*:\([0-9]\+\).*/\\1/")
+    TH_PID=$(grep -Er "($TH_REGEX|custom\.exe)" /proc/*/stat | sed "s/.*:\([0-9]\+\).*/\\1/")
     sleep 5
 done
 

--- a/thcrap_proton
+++ b/thcrap_proton
@@ -121,8 +121,7 @@ echo "$COMMAND"
 echo "---------------------------------------------------------"
 
 sh -c "$COMMAND" &
-
-if [ "$USE_THPRAC" == 1 ]; then
+if [[ "$USE_THPRAC" == 1 && -z $(echo "$COMMAND" | grep -E 'custom\.exe$') ]]; then
     # wait 5s and launch thprac so it could auto attach to the game
     sleep 5
     PROTON_CMD=$( echo "$COMMAND" | sed -n "s/^.*-- \(.*\) waitforexitandrun.*$/\\1/p" )


### PR DESCRIPTION
- Add [thprac](https://github.com/touhouworldcup/thprac) support with additional `-p /path/to/thprac.exe` option.

It will launch the game first then wait 5sec launch thprac with the same WINEPREFIX, so thprac would detect running game and automatically attach to it.

I used suggest command from this comment https://github.com/touhouworldcup/thprac/issues/129#issuecomment-1475398643
and some @redirectto scripts https://github.com/redirectto/thprac-steam-proton-wrapper

I tested with native Steam installation (on Steam Deck) and flatpak version of Steam.

- Use $XDG_DATA_HOME for default location
- Also kill custom.exe