### PR TITLE
Make PID-grabbing regex stricter

### DIFF
--- a/thcrap_proton
+++ b/thcrap_proton
@@ -102,7 +102,7 @@ if [ "$USE_THPRAC" == 1 ]; then
     fi
 fi
 
-TH_REGEX="(th[0-9]+|東方紅魔郷)"
+TH_REGEX="(th[0-9]+\.exe|東方紅魔郷)"
 
 if [ "$USE_VPATCH" == 1 ]; then
     COMMAND=$(

--- a/thcrap_proton
+++ b/thcrap_proton
@@ -102,12 +102,12 @@ if [ "$USE_THPRAC" == 1 ]; then
     fi
 fi
 
-TH_REGEX="(th[0-9]+\.exe|東方紅魔郷)"
+TH_REGEX="\((th[0-9]+|東方紅魔郷)"
 
 if [ "$USE_VPATCH" == 1 ]; then
     COMMAND=$(
         echo "$COMMAND" |
-        sed -r "s/$TH_REGEX/vpatch.exe/"
+        sed -r "s/$TH_REGEX\.exe/vpatch.exe/"
     )
 fi
 

--- a/thcrap_proton
+++ b/thcrap_proton
@@ -102,7 +102,7 @@ if [ "$USE_THPRAC" == 1 ]; then
     fi
 fi
 
-TH_REGEX="\((th[0-9]+|東方紅魔郷)"
+TH_REGEX="(th[0-9]+|東方紅魔郷)"
 
 if [ "$USE_VPATCH" == 1 ]; then
     COMMAND=$(
@@ -134,7 +134,7 @@ fi
 
 # Get PID while ensuring only the actual Touhou executable is chosen
 while [ -z "$TH_PID" ]; do # Loop until a matching process is found
-    TH_PID=$(grep -Er "($TH_REGEX|custom\.exe)" /proc/*/stat | sed "s/.*:\([0-9]\+\).*/\\1/")
+    TH_PID=$(grep -Er "\(($TH_REGEX|custom\.exe)" /proc/*/stat | sed "s/.*:\([0-9]\+\).*/\\1/")
     sleep 5
 done
 

--- a/thcrap_proton
+++ b/thcrap_proton
@@ -107,7 +107,7 @@ TH_REGEX="(th[0-9]+\.exe|東方紅魔郷)"
 if [ "$USE_VPATCH" == 1 ]; then
     COMMAND=$(
         echo "$COMMAND" |
-        sed -r "s/$TH_REGEX\.exe/vpatch.exe/"
+        sed -r "s/$TH_REGEX/vpatch.exe/"
     )
 fi
 


### PR DESCRIPTION
On the Steam Deck OLED, the existing regex will match `ath11k_wq`, the kernel driver for the wireless chipset, and so the script will hang forever waiting for it.  Adding `\.exe` on the end of the regex helps to make sure it only matches Touhou executables.